### PR TITLE
Improvements patch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'org.radarbase'
-version '1.0.0'
+version '1.0.1'
 
 mainClassName = 'org.radarbase.redcap.webapp.GrizzlyServer'
 
@@ -59,29 +59,29 @@ ext.grizzlyVersion = '2.4.4'
 ext.jacksonVersion = '2.11.+'
 
 dependencies {
-    compile group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
     runtimeOnly group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: jerseymediaVersion
 
-    compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet', version: jerseyVersion
-    compile group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: jerseyVersion
+    implementation group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet', version: jerseyVersion
+    implementation group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: jerseyVersion
 
-    compile group: 'org.glassfish.grizzly', name: 'grizzly-http-server', version: grizzlyVersion
-    compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: jerseyVersion
+    implementation group: 'org.glassfish.grizzly', name: 'grizzly-http-server', version: grizzlyVersion
+    implementation group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: jerseyVersion
 
-    compile group: 'org.radarcns', name: 'oauth-client-util', version: radarOauthClientVersion
+    implementation group: 'org.radarcns', name: 'oauth-client-util', version: radarOauthClientVersion
 
-    compile group: 'commons-io', name: 'commons-io', version: apacheCommonsIoVersion
-    compile group: 'org.apache.commons', name: 'commons-lang3', version: apacheCommonsLangVersion
+    implementation group: 'commons-io', name: 'commons-io', version: apacheCommonsIoVersion
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: apacheCommonsLangVersion
 
-    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttp3Version
+    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttp3Version
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     implementation "org.jetbrains.kotlin:kotlin-reflect"
-    compile "com.fasterxml.jackson.module:jackson-module-kotlin:${jacksonVersion}"
-    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}"
-    compile "org.json:json:20170516"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}"
+    implementation "org.json:json:20170516"
 
-    testCompile group: 'junit', name: 'junit', version: junitVersion
+    testImplementation group: 'junit', name: 'junit', version: junitVersion
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
 }
 

--- a/src/integration-test/kotlin/org/radarbase/redcap/integration/IntegratorTest.kt
+++ b/src/integration-test/kotlin/org/radarbase/redcap/integration/IntegratorTest.kt
@@ -3,9 +3,7 @@ package org.radarbase.redcap.integration
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import org.junit.Assert
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.FixMethodOrder
 import org.junit.Test
@@ -101,12 +99,10 @@ class IntegratorTest {
             mpIntegrator = mpIntegrator
         )
 
-        // The result will be false since there is no actual redcap instance and hence the form
-        // cannot be updated. But even then, no exception should be thrown.
         val result = integrator.handleDataEntryTrigger()
-        assertFalse(result)
+        assertTrue(result)
 
-        Assert.assertNotNull(subject)
+        assertNotNull(subject)
         assertEquals(
             Integer.valueOf(REDCAP_RECORD_ID_2),
             subject?.externalId
@@ -136,7 +132,8 @@ class IntegratorTest {
             existingSubjectId
         )
         assertEquals(subject.attributes, attributes)
-        assertEquals(subject.humanReadableIdentifier,
+        assertEquals(
+            subject.humanReadableIdentifier,
             HUMAN_READABLE_ID
         )
     }
@@ -163,10 +160,12 @@ class IntegratorTest {
             existingSubjectId
         )
         assertEquals(subject.attributes, attributes)
-        assertEquals(subject.attributes[REDCAP_ATTRIBUTE_1],
+        assertEquals(
+            subject.attributes[REDCAP_ATTRIBUTE_1],
             REDCAP_ATTRIBUTE_1_VAL_2
         )
-        assertEquals(subject.humanReadableIdentifier,
+        assertEquals(
+            subject.humanReadableIdentifier,
             HUMAN_READABLE_ID
         )
     }

--- a/src/main/kotlin/org/radarbase/redcap/config/Properties.kt
+++ b/src/main/kotlin/org/radarbase/redcap/config/Properties.kt
@@ -227,10 +227,7 @@ object Properties {
      * @return [URL] pointing the Management Portal instance specified on the config file
      */
     fun validateMpUrl(): URL {
-        if (!isSecureConnection(
-                CONFIG.mpConfig.managementPortalUrl
-            )
-        ) {
+        if (!isSecureConnection(CONFIG.mpConfig.managementPortalUrl)) {
             LOGGER.warn(
                 "The provided Management Portal instance is not using an encrypted"
                         + " connection."

--- a/src/main/kotlin/org/radarbase/redcap/integration/Integrator.kt
+++ b/src/main/kotlin/org/radarbase/redcap/integration/Integrator.kt
@@ -3,8 +3,7 @@ package org.radarbase.redcap.integration
 import org.radarbase.redcap.config.RedCapInfo
 import org.radarbase.redcap.config.RedCapManager
 import org.radarbase.redcap.managementportal.MpClient
-import org.radarbase.redcap.managementportal.Subject.SubjectOperationStatus.CREATED
-import org.radarbase.redcap.managementportal.Subject.SubjectOperationStatus.FAILED
+import org.radarbase.redcap.managementportal.Subject.SubjectOperationStatus.*
 import org.radarbase.redcap.util.RedCapClient
 import org.radarbase.redcap.util.RedCapTrigger
 import org.radarbase.redcap.webapp.exception.IllegalRequestException
@@ -85,9 +84,13 @@ class Integrator(
                 integrationFrom
             )
 
-            FAILED -> throw SubjectOperationException(
-                "Operation on Subject in MP failed."
-            )
+            // We send true here too since the integration was successful even though we did not
+            // update the redcap form as it wasn't required. Later, we may update a field in
+            // redcap with attributes from MP in the UPDATED status
+            UPDATED, NOOP -> true
+
+            FAILED -> throw SubjectOperationException("Operation on Subject in MP failed.")
+
             else -> false
         }
     }

--- a/src/main/kotlin/org/radarbase/redcap/integration/MpIntegrator.kt
+++ b/src/main/kotlin/org/radarbase/redcap/integration/MpIntegrator.kt
@@ -113,10 +113,7 @@ class MpIntegrator(private val mpClient: MpClient) {
             }
             createSubject(attributes, humanReadableId, redcapUrl, project, recordId)
         } catch (e: Exception) {
-            throw SubjectOperationException(
-                "Subject creation cannot be completed.",
-                e
-            )
+            throw SubjectOperationException("Subject creation cannot be completed.", e)
         }
     }
 

--- a/src/main/kotlin/org/radarbase/redcap/managementportal/MpClient.kt
+++ b/src/main/kotlin/org/radarbase/redcap/managementportal/MpClient.kt
@@ -5,12 +5,12 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
-import org.radarcns.exception.TokenException
-import org.radarcns.oauth.OAuth2Client
 import org.radarbase.redcap.config.Properties
 import org.radarbase.redcap.config.RedCapManager
 import org.radarbase.redcap.webapp.exception.IllegalRequestException
 import org.radarbase.redcap.webapp.exception.SubjectOperationException
+import org.radarcns.exception.TokenException
+import org.radarcns.oauth.OAuth2Client
 import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.net.MalformedURLException
@@ -51,7 +51,10 @@ open class MpClient @Inject constructor(private val httpClient: OkHttpClient) {
 
     @get:Throws(TokenException::class)
     private val token: String
-        get() = oauthClient.getValidToken(Duration.ofSeconds(30)).accessToken
+        get() {
+            LOGGER.info("Trying to get token from {}", oauthClient.tokenEndpoint.toString())
+            return oauthClient.getValidToken(Duration.ofSeconds(30)).accessToken
+        }
 
     @Throws(IOException::class)
     fun getProject(redcapUrl: URL, projectId: Int): Project {

--- a/src/main/kotlin/org/radarbase/redcap/webapp/exception/IllegalRequestException.kt
+++ b/src/main/kotlin/org/radarbase/redcap/webapp/exception/IllegalRequestException.kt
@@ -1,5 +1,6 @@
 package org.radarbase.redcap.webapp.exception
 
+import org.slf4j.LoggerFactory
 import javax.ws.rs.core.Response
 import javax.ws.rs.ext.ExceptionMapper
 import javax.ws.rs.ext.Provider
@@ -11,9 +12,15 @@ class IllegalRequestException @JvmOverloads constructor(
 ) :
     IllegalStateException(msg, throwable), ExceptionMapper<IllegalRequestException> {
 
-    override fun toResponse(exception: IllegalRequestException?): Response =
-        Response.status(400).entity(
+    override fun toResponse(exception: IllegalRequestException?): Response {
+        logger.error("Bad Request! 400", exception)
+        return Response.status(400).entity(
             "The request was not successful. Please verify its validity. ${exception?.msg}" +
                     "\n${exception?.throwable}"
         ).type("text/plain").build()
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(IllegalRequestException::class.java)
+    }
 }

--- a/src/main/kotlin/org/radarbase/redcap/webapp/exception/RedcapOperationException.kt
+++ b/src/main/kotlin/org/radarbase/redcap/webapp/exception/RedcapOperationException.kt
@@ -1,5 +1,6 @@
 package org.radarbase.redcap.webapp.exception
 
+import org.slf4j.LoggerFactory
 import java.io.IOException
 import javax.ws.rs.core.Response
 import javax.ws.rs.ext.ExceptionMapper
@@ -12,9 +13,15 @@ class RedcapOperationException @JvmOverloads constructor(
 ) :
     IOException(msg, throwable), ExceptionMapper<RedcapOperationException> {
 
-    override fun toResponse(exception: RedcapOperationException?): Response =
-        Response.status(500).entity(
+    override fun toResponse(exception: RedcapOperationException?): Response {
+        logger.error("Error has occurred while operating on the redcap instance. 500", exception)
+        return Response.status(500).entity(
             "An Error has occurred while operating on the redcap instance. ${exception?.msg}" +
                     "\n${exception?.throwable}"
         ).type("text/plain").build()
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(RedcapOperationException::class.java)
+    }
 }

--- a/src/main/kotlin/org/radarbase/redcap/webapp/exception/SubjectOperationException.kt
+++ b/src/main/kotlin/org/radarbase/redcap/webapp/exception/SubjectOperationException.kt
@@ -1,5 +1,6 @@
 package org.radarbase.redcap.webapp.exception
 
+import org.slf4j.LoggerFactory
 import java.io.IOException
 import javax.ws.rs.core.Response
 import javax.ws.rs.ext.ExceptionMapper
@@ -12,9 +13,15 @@ class SubjectOperationException @JvmOverloads constructor(
 ) :
     IOException(msg, throwable), ExceptionMapper<SubjectOperationException> {
 
-    override fun toResponse(exception: SubjectOperationException?): Response =
-        Response.status(500).entity(
+    override fun toResponse(exception: SubjectOperationException?): Response {
+        logger.error("Error has occurred while operating on the subject. 500", exception)
+        return Response.status(500).entity(
             "An Error has occurred while operating on the subject. ${exception?.msg}" +
                     "\n${exception?.throwable}"
         ).type("text/plain").build()
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(SubjectOperationException::class.java)
+    }
 }

--- a/src/main/kotlin/org/radarbase/redcap/webapp/exception/UncaughtIOException.kt
+++ b/src/main/kotlin/org/radarbase/redcap/webapp/exception/UncaughtIOException.kt
@@ -1,5 +1,6 @@
 package org.radarbase.redcap.webapp.exception
 
+import org.slf4j.LoggerFactory
 import java.io.IOException
 import javax.ws.rs.core.Response
 import javax.ws.rs.ext.ExceptionMapper
@@ -8,9 +9,15 @@ import javax.ws.rs.ext.Provider
 @Provider
 class UncaughtIOException : IOException(), ExceptionMapper<IOException> {
 
-    override fun toResponse(exception: IOException?): Response =
-        Response.status(500).entity(
+    override fun toResponse(exception: IOException?): Response {
+        logger.error("An I/O Exception has occurred while processing the request. 500", exception)
+        return Response.status(500).entity(
             "An I/O Exception has occurred while processing the request. ${exception?.message}" +
                     "\n${exception?.cause}"
         ).type("text/plain").build()
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(UncaughtIOException::class.java)
+    }
 }

--- a/src/main/kotlin/org/radarbase/redcap/webapp/exception/UncaughtTokenException.kt
+++ b/src/main/kotlin/org/radarbase/redcap/webapp/exception/UncaughtTokenException.kt
@@ -1,6 +1,7 @@
 package org.radarbase.redcap.webapp.exception
 
 import org.radarcns.exception.TokenException
+import org.slf4j.LoggerFactory
 import javax.ws.rs.core.Response
 import javax.ws.rs.ext.ExceptionMapper
 import javax.ws.rs.ext.Provider
@@ -8,9 +9,15 @@ import javax.ws.rs.ext.Provider
 @Provider
 class UncaughtTokenException : TokenException(), ExceptionMapper<TokenException> {
 
-    override fun toResponse(exception: TokenException?): Response =
-        Response.status(401).entity(
-            "The request was not successful. Please verify its validity. ${exception?.message}" +
+    override fun toResponse(exception: TokenException?): Response {
+        logger.error("Error getting token from Management portal. Unauthorized! 401", exception)
+        return Response.status(401).entity(
+            "Error getting token from Management portal. ${exception?.message}" +
                     "\n${exception?.cause}"
         ).type("text/plain").build()
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(UncaughtTokenException::class.java)
+    }
 }


### PR DESCRIPTION
On testing with actual redcap instance, though everything worked fine, found some room for improvements -

1. The exceptions were only added in http response but since redcap discards any response for the trigger, we need to log the exceptions to standard out/err for transparency.
2. even though everything was working fine, the app still threw exception on UPDATE and NOOP status. This was semantically correct for the local function but not for the final response. Updated it to provide a success response.
3. Remove catching base exception as we now have exception mappers.