### PR TITLE
Api path config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ ext.jerseymediaVersion = '2.30.1'
 ext.junitVersion = '4.12'
 ext.logbackVersion = '1.2.3'
 ext.okhttp3Version = '3.8.1'
-ext.radarOauthClientVersion = '0.5.8'
+ext.radarOauthClientVersion = '0.8.0'
 ext.grizzlyVersion = '2.4.4'
 ext.jacksonVersion = '2.11.+'
 
@@ -68,7 +68,7 @@ dependencies {
     implementation group: 'org.glassfish.grizzly', name: 'grizzly-http-server', version: grizzlyVersion
     implementation group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: jerseyVersion
 
-    implementation group: 'org.radarcns', name: 'oauth-client-util', version: radarOauthClientVersion
+    implementation group: 'org.radarbase', name: 'oauth-client-util', version: radarOauthClientVersion
 
     implementation group: 'commons-io', name: 'commons-io', version: apacheCommonsIoVersion
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: apacheCommonsLangVersion

--- a/src/main/kotlin/org/radarbase/redcap/config/RedCapInfo.kt
+++ b/src/main/kotlin/org/radarbase/redcap/config/RedCapInfo.kt
@@ -27,6 +27,7 @@ import java.net.URL
 data class RedCapInfo(
     @JsonProperty("url") var url: URL,
     @JsonProperty("project_id") val projectId: Int,
+    @JsonProperty("api_path") val apiPath: String = "/api/",
     @JsonProperty("enrolment_event") val enrolmentEvent: String? = null,
     @JsonProperty("integration_form") val integrationForm: String? = null,
     @JsonProperty("token") val token: String? = null,

--- a/src/main/kotlin/org/radarbase/redcap/managementportal/MpClient.kt
+++ b/src/main/kotlin/org/radarbase/redcap/managementportal/MpClient.kt
@@ -9,8 +9,8 @@ import org.radarbase.redcap.config.Properties
 import org.radarbase.redcap.config.RedCapManager
 import org.radarbase.redcap.webapp.exception.IllegalRequestException
 import org.radarbase.redcap.webapp.exception.SubjectOperationException
-import org.radarcns.exception.TokenException
-import org.radarcns.oauth.OAuth2Client
+import org.radarbase.exception.TokenException
+import org.radarbase.oauth.OAuth2Client
 import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.net.MalformedURLException

--- a/src/main/kotlin/org/radarbase/redcap/util/RedCapClient.kt
+++ b/src/main/kotlin/org/radarbase/redcap/util/RedCapClient.kt
@@ -48,7 +48,7 @@ open class RedCapClient(private val redCapInfo: RedCapInfo) {
     @get:Throws(MalformedURLException::class)
     val apiUrl: URL
         get() = URL(redCapInfo.url.protocol, redCapInfo.url.host, redCapInfo.url.port,
-            API_ROOT
+            redCapInfo.apiPath
         )
 
     @Throws(IOException::class)
@@ -173,7 +173,6 @@ open class RedCapClient(private val redCapInfo: RedCapInfo) {
         }
 
         private val LOGGER = LoggerFactory.getLogger(RedCapClient::class.java)
-        private const val API_ROOT = "/redcap/api/"
         private const val TOKEN_LABEL = "token"
         private const val DATA_LABEL = "data"
         private const val FIELDS_LABEL = "fields"

--- a/src/main/kotlin/org/radarbase/redcap/util/RedCapClient.kt
+++ b/src/main/kotlin/org/radarbase/redcap/util/RedCapClient.kt
@@ -138,7 +138,7 @@ open class RedCapClient(private val redCapInfo: RedCapInfo) {
     private fun getErrorMsg(response: Response): String {
         var msg = "Request to Redcap was unsuccessful. Code: ${response.code()}, " +
                 "Msg: ${response.message()}"
-        val body = response.body();
+        val body = response.body()
         if(body != null) {
             msg += ", Reason: ${body.string()}"
         }

--- a/src/main/kotlin/org/radarbase/redcap/webapp/exception/UncaughtTokenException.kt
+++ b/src/main/kotlin/org/radarbase/redcap/webapp/exception/UncaughtTokenException.kt
@@ -1,6 +1,6 @@
 package org.radarbase.redcap.webapp.exception
 
-import org.radarcns.exception.TokenException
+import org.radarbase.exception.TokenException
 import org.slf4j.LoggerFactory
 import javax.ws.rs.core.Response
 import javax.ws.rs.ext.ExceptionMapper


### PR DESCRIPTION
Make redcap API path configurable as it can vary depending on the deployments (due to reverse proxies, etc)