### PR TITLE
Add sources to Subject data class

### DIFF
--- a/src/integration-test/kotlin/org/radarbase/redcap/EntryPointTest.kt
+++ b/src/integration-test/kotlin/org/radarbase/redcap/EntryPointTest.kt
@@ -34,7 +34,7 @@ class EntryPointTest {
         val subject: Subject? =
             mpClient.getSubject(URL(REDCAP_URL), REDCAP_PROJECT_ID, REDCAP_RECORD_ID_2)
         Assert.assertNotNull(subject)
-        Assert.assertEquals(Integer.valueOf(REDCAP_RECORD_ID_2), subject?.externalId)
+        Assert.assertEquals(REDCAP_RECORD_ID_2.toString(), subject?.externalId)
         Assert.assertEquals(
             "$WORK_PACKAGE-$MP_PROJECT_ID-$MP_PROJECT_LOCATION-$REDCAP_RECORD_ID_2",
             subject?.humanReadableIdentifier

--- a/src/integration-test/kotlin/org/radarbase/redcap/integration/IntegratorTest.kt
+++ b/src/integration-test/kotlin/org/radarbase/redcap/integration/IntegratorTest.kt
@@ -105,7 +105,7 @@ class IntegratorTest {
 
         assertNotNull(subject)
         assertEquals(
-            Integer.valueOf(REDCAP_RECORD_ID_2),
+            REDCAP_RECORD_ID_2.toString(),
             subject?.externalId
         )
         assertEquals(

--- a/src/integration-test/kotlin/org/radarbase/redcap/managementportal/MpClientTest.kt
+++ b/src/integration-test/kotlin/org/radarbase/redcap/managementportal/MpClientTest.kt
@@ -51,7 +51,7 @@ class MpClientTest {
             )
         Assert.assertNotNull(subject)
         Assert.assertEquals(
-            Integer.valueOf(IntegrationUtils.REDCAP_RECORD_ID_1),
+            IntegrationUtils.REDCAP_RECORD_ID_1.toString(),
             subject!!.externalId
         )
         Assert.assertEquals(

--- a/src/main/kotlin/org/radarbase/redcap/config/RedCapManager.kt
+++ b/src/main/kotlin/org/radarbase/redcap/config/RedCapManager.kt
@@ -97,7 +97,7 @@ object RedCapManager {
      * @throws NoSuchElementException In case the [URL] does not contain any characters
      */
     @Throws(MalformedURLException::class, NoSuchElementException::class)
-    fun getRecordUrl(redCapUrl: URL, projectId: Int, recordId: Int): URL {
+    fun getRecordUrl(redCapUrl: URL, projectId: Int, recordId: Int): String {
         val redCapInfo = getRedCapInfo(redCapUrl, projectId)
         var redCap = redCapInfo.url.toString()
 
@@ -107,6 +107,6 @@ object RedCapManager {
 
         redCap = "$redCap$PROJECT_ID$projectId$RECORD_ID$recordId" +
                 "$EVENT_ID${redCapInfo.enrolmentEvent}$PAGE_NAME${redCapInfo.integrationForm}"
-        return URL(redCap)
+        return URL(redCap).toString()
     }
 }

--- a/src/main/kotlin/org/radarbase/redcap/managementportal/MpClient.kt
+++ b/src/main/kotlin/org/radarbase/redcap/managementportal/MpClient.kt
@@ -129,7 +129,7 @@ open class MpClient @Inject constructor(private val httpClient: OkHttpClient) {
         val radarSubjectId = UUID.randomUUID().toString()
         val subject = Subject(
             subjectId = radarSubjectId,
-            externalId = recordId,
+            externalId = recordId.toString(),
             externalLink = RedCapManager.getRecordUrl(
                 redcapUrl,
                 project.redCapId!!,
@@ -182,26 +182,23 @@ open class MpClient @Inject constructor(private val httpClient: OkHttpClient) {
                 recordId
             )
         ).get().build()
-
         return performRequest(
             request = request,
             onSuccess = { response ->
-                val subjects =
-                    Subject.subjects(
-                        response
-                    )
-                if (subjects.size == 0) {
-                    LOGGER.info("Subject is not present")
+                val subjects = Subject.subjects(response)
+                    .filter { it.externalId.toString() == recordId.toString() }
+                if (subjects.isEmpty()) {
+                    LOGGER.info("Subject with externalId $recordId is not present")
                     return@performRequest null
                 }
+    
                 check(subjects.size <= 1) {
-                    ("More than 1 subjects exist with same "
-                            + "externalId in the same Project")
+                    "More than one subject exists with the same externalId ($recordId) in the same project"
                 }
-                subjects[0]
+                subjects.first()
             },
             onError = {
-                LOGGER.info("Subject is not present")
+                LOGGER.info("Failed to retrieve subject with externalId $recordId")
                 null
             },
             errorMessage = "Subject could not be retrieved"
@@ -264,6 +261,7 @@ open class MpClient @Inject constructor(private val httpClient: OkHttpClient) {
                 .addPathSegment(projectName)
                 .addPathSegment("subjects")
                 .addQueryParameter("externalId", recordId.toString())
+                .addQueryParameter("size", Int.MAX_VALUE.toString())
                 .build()
             return subjectUrl.toUrl()
         }

--- a/src/main/kotlin/org/radarbase/redcap/managementportal/Organization.kt
+++ b/src/main/kotlin/org/radarbase/redcap/managementportal/Organization.kt
@@ -3,6 +3,9 @@ package org.radarbase.redcap.managementportal
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
@@ -30,6 +33,19 @@ class OrganizationDeserializer : JsonDeserializer<Organization>() {
             else -> {
                 val org = p.codec.treeToValue(node, OrganizationObject::class.java)
                 Organization.ObjectOrganization(org)
+            }
+        }
+    }
+}
+
+class OrganizationSerializer : JsonSerializer<Organization>() {
+    override fun serialize(value: Organization, gen: JsonGenerator, serializers: SerializerProvider) {
+        when (value) {
+            is Organization.StringOrganization -> {
+                gen.writeString(value.value)  // Serialize as a string
+            }
+            is Organization.ObjectOrganization -> {
+                gen.writeObject(value.value)  // Assuming OrganizationObject is a class
             }
         }
     }

--- a/src/main/kotlin/org/radarbase/redcap/managementportal/Project.kt
+++ b/src/main/kotlin/org/radarbase/redcap/managementportal/Project.kt
@@ -3,6 +3,7 @@ package org.radarbase.redcap.managementportal
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
@@ -32,7 +33,12 @@ import org.radarbase.redcap.managementportal.Organization
 data class Project(
     @JsonProperty("id") val id: Int,
     @JsonProperty("projectName") val projectName: String,
-    @JsonProperty("organization") @JsonDeserialize(using = OrganizationDeserializer::class) val organization: Organization,
+
+    @JsonProperty("organization") 
+    @JsonDeserialize(using = OrganizationDeserializer::class) 
+    @JsonSerialize(using = OrganizationSerializer::class)
+    val organization: Organization,
+
     @JsonProperty("location") val location: String = "",
     @JsonProperty("attributes") val attributes: Map<String, String> = emptyMap()
 ) {

--- a/src/main/kotlin/org/radarbase/redcap/managementportal/Source.kt
+++ b/src/main/kotlin/org/radarbase/redcap/managementportal/Source.kt
@@ -1,0 +1,41 @@
+package org.radarbase.redcap.managementportal
+
+import java.util.*
+
+
+/*
+ * Copyright 2017 King's College London
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Constructor.
+ * @param subjectId [String] representing Management Portal Subject identifier
+ * @param externalId [Integer] representing the REDCap Record identifier
+ * @param externalLink [URL] pointing the REDCap integration form / instrument
+ * @param project [Project] associated with the subject
+ * @param attributes [Map] of key,value pairs
+ */
+data class Source(
+    var id: Long? = null,
+    var sourceTypeId: Long? = null,
+    var sourceTypeProducer: String? = null,
+    var sourceTypeModel: String? = null,
+    var sourceTypeCatalogVersion: String? = null,
+    var expectedSourceName: String? = null,
+    var sourceId: UUID? = null,
+    var sourceName: String? = null,
+    var isAssigned: Boolean? = null,
+    var attributes: MutableMap<String, String> = HashMap()
+)

--- a/src/main/kotlin/org/radarbase/redcap/managementportal/Source.kt
+++ b/src/main/kotlin/org/radarbase/redcap/managementportal/Source.kt
@@ -19,14 +19,6 @@ import java.util.*
  * limitations under the License.
  */
 
-/**
- * Constructor.
- * @param subjectId [String] representing Management Portal Subject identifier
- * @param externalId [Integer] representing the REDCap Record identifier
- * @param externalLink [URL] pointing the REDCap integration form / instrument
- * @param project [Project] associated with the subject
- * @param attributes [Map] of key,value pairs
- */
 data class Source(
     var id: Long? = null,
     var sourceTypeId: Long? = null,

--- a/src/main/kotlin/org/radarbase/redcap/managementportal/Subject.kt
+++ b/src/main/kotlin/org/radarbase/redcap/managementportal/Subject.kt
@@ -43,7 +43,8 @@ data class Subject(
     @JsonProperty("externalLink") val externalLink: URL? = null,
     @JsonProperty("project") var project: Project? = null,
     @JsonProperty("attributes") val attributes: MutableMap<String, String> = mutableMapOf(),
-    @JsonProperty("status") val status: String = SubjectStatus.ACTIVATED.toString()
+    @JsonProperty("status") val status: String = SubjectStatus.ACTIVATED.toString(),
+    @JsonProperty("sources") val sources: Set<Source> = emptySet()
 ) {
     enum class SubjectStatus {
         DEACTIVATED, ACTIVATED, DISCONTINUED, INVALID

--- a/src/main/kotlin/org/radarbase/redcap/managementportal/Subject.kt
+++ b/src/main/kotlin/org/radarbase/redcap/managementportal/Subject.kt
@@ -31,20 +31,20 @@ import java.net.URL
 /**
  * Constructor.
  * @param subjectId [String] representing Management Portal Subject identifier
- * @param externalId [Integer] representing the REDCap Record identifier
- * @param externalLink [URL] pointing the REDCap integration form / instrument
+ * @param externalId [String] representing the REDCap Record identifier
+ * @param externalLink [String] pointing the REDCap integration form / instrument
  * @param project [Project] associated with the subject
  * @param attributes [Map] of key,value pairs
  */
 data class Subject(
     @JsonProperty("id") val mpId: Long?,
     @JsonProperty("login") val subjectId: String,
-    @JsonProperty("externalId") val externalId: Int? = null,
-    @JsonProperty("externalLink") val externalLink: URL? = null,
+    @JsonProperty("externalId") val externalId: String? = null,
+    @JsonProperty("externalLink") val externalLink: String? = null,
     @JsonProperty("project") var project: Project? = null,
     @JsonProperty("attributes") val attributes: MutableMap<String, String> = mutableMapOf(),
     @JsonProperty("status") val status: String = SubjectStatus.ACTIVATED.toString(),
-    @JsonProperty("sources") val sources: Set<Source> = emptySet()
+    @JsonProperty("sources") val sources: List<Source> = emptyList()
 ) {
     enum class SubjectStatus {
         DEACTIVATED, ACTIVATED, DISCONTINUED, INVALID
@@ -63,13 +63,13 @@ data class Subject(
      * Constructor.
      * @param subjectId [String] representing Management Portal Subject identifier
      * @param externalId [Integer] representing the REDCap Record identifier
-     * @param externalLink [URL] pointing the REDCap integration form / instrument
+     * @param  [URL] pointing the REDCap integration form / instrument
      * @param project [Project] associated with the subject
      * @param humanReadableId [String] representing the value associated with
      * [.HUMAN_READABLE_IDENTIFIER_KEY]
      */
     constructor(
-        subjectId: String, externalId: Int, externalLink: URL, project: Project,
+        subjectId: String, externalId: String, externalLink: String, project: Project,
         humanReadableId: String
     ) : this(
         null, subjectId, externalId, externalLink, project,
@@ -78,8 +78,8 @@ data class Subject(
 
     constructor(
         subjectId: String,
-        externalId: Int,
-        externalLink: URL,
+        externalId: String,
+        externalLink: String,
         project: Project,
         humanReadableId: String,
         attributes: Map<String, String>


### PR DESCRIPTION
- When the subject gets updated with new attributes the source property is empty which causes source deletion in MP, this adds sources to the Subject class
- Updated `Subject` `externalId` and `externalLink` to string
- Added `Organization` serializer for requests back to MP

Solves #76
